### PR TITLE
Added BIP32 key definitions, no implementation

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -70,6 +70,8 @@ public:
         base58Prefixes[PUBKEY_ADDRESS] = 130;
         base58Prefixes[SCRIPT_ADDRESS] = 30;
         base58Prefixes[SECRET_KEY] = 224;
+        base58Prefixes[EXT_PUBLIC_KEY] = list_of(0x04)(0x88)(0xB2)(0x1E);
+        base58Prefixes[EXT_SECRET_KEY] = list_of(0x04)(0x88)(0xAD)(0xE4);
 
         // Convert the pnSeeds array into usable address objects.
         for (unsigned int i = 0; i < ARRAYLEN(pnSeed); i++)


### PR DESCRIPTION
Defined EXT_PUBLIC_KEY and EXT_SECRET_KEY used to serialize public BIP32 addresses. No implementation, just the definition as some downstream applications need guidance. Used bitcoin values as I don't see a clear reason not to.